### PR TITLE
mod_apn: remove duplicate registration log line

### DIFF
--- a/mod_apn/mod_apn.c
+++ b/mod_apn/mod_apn.c
@@ -954,8 +954,6 @@ static void originate_register_event_handler(switch_event_t *event)
 	switch_mutex_unlock(handles_mutex);
 
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "mod_apn:. Try originate to '%s' (by registration event) for callId '%s' \n", destination, originate_data->x_call_id);
-
-	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "mod_apn:. Try originate to '%s' (by registration event) for callId '%s' \n", destination, originate_data->x_call_id);
 	switch_safe_free(destination);
 	switch_safe_free(dest);
 }


### PR DESCRIPTION
## Summary
- Remove redundant `switch_log_printf` in `originate_register_event_handler` so registration-based originates log only once

## Testing
- `rg "Try originate to '" mod_apn/mod_apn.c`
- `make` *(fails: No targets specified and no makefile found)*
- `gcc -c mod_apn/mod_apn.c` *(fails: switch.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68ba2a09ffd4832aad4d8be05a6270e4