### PR TITLE
Add curl timeouts and HTTP status checks to httpPost

### DIFF
--- a/fcm_push.php
+++ b/fcm_push.php
@@ -208,14 +208,23 @@ function httpPost($url, $data, $headers)
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
 
     $result = curl_exec($ch);
 
     if (curl_errno($ch)) {
-        throw new Exception('Curl Error: ' . curl_error($ch));
+        $error = curl_error($ch);
+        curl_close($ch);
+        throw new Exception('Curl Error: ' . $error);
     }
 
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
+
+    if ($httpCode < 200 || $httpCode >= 300) {
+        throw new Exception('HTTP request failed with status ' . $httpCode);
+    }
 
     return json_decode($result, true);
 }


### PR DESCRIPTION
## Summary
- Set cURL connect and overall timeouts in httpPost
- Throw exception on non-2xx HTTP responses

## Testing
- `php -l fcm_push.php`
- `php -r '$GLOBALS["_REQUEST"]=[]; include "fcm_push.php"; try { httpPost("https://httpbin.org/status/500", "", []); } catch (Exception $e) { echo "Caught: ".$e->getMessage()."\n"; }'`


------
https://chatgpt.com/codex/tasks/task_b_68ba2f6dd6cc832aa3d3d6b3dd46603b