### PR TITLE
Fix cleanup label in originate_register_event_handler

### DIFF
--- a/mod_apn/mod_apn.c
+++ b/mod_apn/mod_apn.c
@@ -929,7 +929,7 @@ static void originate_register_event_handler(switch_event_t *event)
         {
                 // Prevent negative or zero timelimit
                 switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "mod_apn: Invalid timelimit_sec before try originate (%d), skipping originate for callId '%s'\n", *originate_data->timelimit, originate_data->x_call_id);
-                return;
+                goto end;
         }
         else if (*originate_data->timelimit > 30)
         {

--- a/mod_apn/mod_apn.c
+++ b/mod_apn/mod_apn.c
@@ -957,8 +957,10 @@ static void originate_register_event_handler(switch_event_t *event)
 	originate_data->destination = switch_core_strdup(pool, destination);
 	switch_mutex_unlock(handles_mutex);
 
-	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "mod_apn:. Try originate to '%s' (by registration event) for callId '%s' \n", destination, originate_data->x_call_id);
+        switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "mod_apn:. Try originate to '%s' (by registration event) for callId '%s' \n", destination, originate_data->x_call_id);
 	switch_safe_free(destination);
+
+end:
 	switch_safe_free(dest);
 }
 


### PR DESCRIPTION
## Summary
- add end label and free `dest` after freeing `destination` in `originate_register_event_handler`

## Testing
- `make -C mod_apn` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_b_68bd02da5ad0832a8df89197438ea670