### PR TITLE
Handle expired push tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Push notifications module for FreeSWITCH, designed for deployments such as [Fusi
 
 `mod_apn` listens to `sofia::register` events, parses the `Contact` header from SIP REGISTER, and stores device push notification tokens (VoIP and IM) into your database. When a call is generated to a user with a stored token, the endpoint `apn_wait` sends an HTTP request to your push server (FCM/APNs) with all info regarding the device.
 
+Expired or invalid tokens are now reported with HTTP 410 responses from `fcm_push.php`, and `mod_apn` will automatically remove those entries from the `push_tokens` table when APNs returns the same status.
+
 ---
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Push notifications module for FreeSWITCH, designed for deployments such as [Fusi
 
 `mod_apn` listens to `sofia::register` events, parses the `Contact` header from SIP REGISTER, and stores device push notification tokens (VoIP and IM) into your database. When a call is generated to a user with a stored token, the endpoint `apn_wait` sends an HTTP request to your push server (FCM/APNs) with all info regarding the device.
 
-Expired or invalid tokens are now reported with HTTP 410 responses from `fcm_push.php`, and `mod_apn` will automatically remove those entries from the `push_tokens` table when APNs returns the same status.
+Expired or invalid tokens are now reported with HTTP 410 responses from `fcm_push.php`, and `mod_apn` will automatically remove those entries from the `push_tokens` table when it receives this status.
 
 ---
 

--- a/fcm_push.php
+++ b/fcm_push.php
@@ -16,6 +16,86 @@ define('APNS_TEAM_ID', 'YOUR_TEAM_ID'); // Apple developer team ID
 define('APNS_BUNDLE_ID', 'com.example.app.voip'); // VoIP bundle identifier
 define('APNS_HOST', 'api.push.apple.com'); // Use api.development.push.apple.com for sandbox
 
+class PushServiceException extends Exception
+{
+}
+
+class HttpRequestException extends Exception
+{
+    private int $statusCode;
+    private string $responseBody;
+
+    public function __construct(string $message, int $statusCode, string $responseBody = '', ?Throwable $previous = null)
+    {
+        parent::__construct($message, $statusCode, $previous);
+        $this->statusCode = $statusCode;
+        $this->responseBody = $responseBody;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getResponseBody(): string
+    {
+        return $this->responseBody;
+    }
+}
+
+class APNsException extends PushServiceException
+{
+    private int $status;
+    private string $responseBody;
+
+    public function __construct(string $message, int $status, string $responseBody = '', ?Throwable $previous = null)
+    {
+        parent::__construct($message, $status, $previous);
+        $this->status = $status;
+        $this->responseBody = $responseBody;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    public function getResponseBody(): string
+    {
+        return $this->responseBody;
+    }
+}
+
+class FCMException extends PushServiceException
+{
+    private int $status;
+    private ?string $errorCode;
+    private string $responseBody;
+
+    public function __construct(string $message, int $status, ?string $errorCode = null, string $responseBody = '', ?Throwable $previous = null)
+    {
+        parent::__construct($message, $status, $previous);
+        $this->status = $status;
+        $this->errorCode = $errorCode;
+        $this->responseBody = $responseBody;
+    }
+
+    public function getStatus(): int
+    {
+        return $this->status;
+    }
+
+    public function getErrorCode(): ?string
+    {
+        return $this->errorCode;
+    }
+
+    public function getResponseBody(): string
+    {
+        return $this->responseBody;
+    }
+}
+
 /**
  * Get Firebase project ID and credentials from JSON.
  */
@@ -106,17 +186,50 @@ function sendPushNotification($token, $deviceToken, $projectId, $data = [])
         ]
     ];
 
-    $response = httpPost(
-        "https://fcm.googleapis.com/v1/projects/$projectId/messages:send",
-        json_encode($payload),
-        [
-            'Authorization: Bearer ' . $token,
-            'Content-Type: application/json'
-        ]
-    );
+    try {
+        $response = httpPost(
+            "https://fcm.googleapis.com/v1/projects/$projectId/messages:send",
+            json_encode($payload),
+            [
+                'Authorization: Bearer ' . $token,
+                'Content-Type: application/json'
+            ]
+        );
+    } catch (HttpRequestException $e) {
+        $errorCode = null;
+        $body = $e->getResponseBody();
+        if (!empty($body)) {
+            $decoded = json_decode($body, true);
+            if (isset($decoded['error']['status'])) {
+                $errorCode = $decoded['error']['status'];
+            }
+            if (isset($decoded['error']['details']) && is_array($decoded['error']['details'])) {
+                foreach ($decoded['error']['details'] as $detail) {
+                    if (is_array($detail) && isset($detail['errorCode'])) {
+                        $errorCode = $detail['errorCode'];
+                        break;
+                    }
+                }
+            }
+        }
+
+        throw new FCMException(
+            $errorCode ? 'FCM Error: ' . $errorCode : 'FCM Error: HTTP ' . $e->getStatusCode(),
+            $e->getStatusCode(),
+            $errorCode,
+            $body,
+            $e
+        );
+    }
 
     if (empty($response['name'])) {
-        throw new Exception(empty($response) ? 'Failed to send push notification.' : json_encode($response));
+        $body = json_encode($response);
+        throw new FCMException(
+            'FCM Error: Missing response name',
+            500,
+            null,
+            $body === 'null' ? '' : $body
+        );
     }
 
     logMessage("Notification sent successfully. Response ID: {$response['name']}"); // Log success
@@ -174,14 +287,16 @@ function sendVoipPushNotification($deviceToken, $data = [])
     $result = curl_exec($ch);
 
     if (curl_errno($ch)) {
-        throw new Exception('Curl Error: ' . curl_error($ch));
+        $error = curl_error($ch);
+        curl_close($ch);
+        throw new APNsException('APNs transport error: ' . $error, 0);
     }
 
     $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
 
     if ($status != 200) {
-        throw new Exception('APNs Error (' . $status . '): ' . $result);
+        throw new APNsException('APNs Error', $status, (string)$result);
     }
 
     logMessage("VoIP notification sent successfully. Response: {$result}");
@@ -206,7 +321,7 @@ function httpPost($url, $data, $headers)
     if (curl_errno($ch)) {
         $error = curl_error($ch);
         curl_close($ch);
-        throw new Exception('Curl Error: ' . $error);
+        throw new HttpRequestException('Curl Error: ' . $error, 0);
     }
 
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -220,7 +335,7 @@ function httpPost($url, $data, $headers)
             $message .= ': ' . $result;
         }
 
-        throw new Exception($message);
+        throw new HttpRequestException($message, $httpCode, (string)$result);
     }
 
     return $decoded;
@@ -280,13 +395,21 @@ try {
     http_response_code(200);
     logMessage("Push notification sent to device token: $deviceToken with data: " . json_encode($inputData)); // Log success
 
-} catch (Exception $e) {
+} catch (PushServiceException $e) {
     $errorMessage = $e->getMessage();
     logMessage("Error: " . $errorMessage); // Log error
-    if (stripos($errorMessage, 'UNREGISTERED') !== false || preg_match('/\b410\b/', $errorMessage)) {
+
+    if (($e instanceof APNsException && $e->getStatus() === 410) ||
+        ($e instanceof FCMException && strtoupper((string)$e->getErrorCode()) === 'UNREGISTERED')) {
         http_response_code(410);
     } else {
         http_response_code(500);
     }
+
+    echo "Error: " . $errorMessage . "\n";
+} catch (Exception $e) {
+    $errorMessage = $e->getMessage();
+    logMessage("Error: " . $errorMessage); // Log error
+    http_response_code(500);
     echo "Error: " . $errorMessage . "\n";
 }

--- a/mod_apn/mod_apn.c
+++ b/mod_apn/mod_apn.c
@@ -133,6 +133,61 @@ static void execute_sql_now(char **sqlp)
 	*sqlp = NULL;
 }
 
+static void mod_apn_delete_token(const char *token, const char *app_id, const char *realm, const char *extension)
+{
+	switch_cache_db_handle_t *dbh = NULL;
+	char *sql = NULL;
+	char *errmsg = NULL;
+
+	if (zstr(token) || zstr(app_id) || zstr(realm) || zstr(extension))
+	{
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+				"mod_apn: Cannot delete expired token, missing context (token/app_id/realm/extension)\n");
+		return;
+	}
+
+	if (!(dbh = mod_apn_get_db_handle()))
+	{
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+				"mod_apn: Error opening DB when deleting expired token '%s'\n", token);
+		return;
+	}
+
+	sql = switch_mprintf("DELETE FROM push_tokens WHERE token = '%q' AND app_id = '%q' AND realm = '%q' AND extension = '%q'",
+			token, app_id, realm, extension);
+
+	if (!sql)
+	{
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+				"mod_apn: Failed to allocate SQL for deleting token '%s'\n", token);
+		goto end;
+	}
+
+	switch_mutex_lock(globals.dbh_mutex);
+	switch_cache_db_execute_sql_callback(dbh, sql, NULL, NULL, &errmsg);
+	switch_mutex_unlock(globals.dbh_mutex);
+
+	if (errmsg)
+	{
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR,
+				"mod_apn: SQL error removing token '%s': %s\n", token, errmsg);
+		free(errmsg);
+	}
+	else
+	{
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_INFO,
+				"mod_apn: Removed expired token '%s' for app_id '%s', realm '%s', extension '%s'\n",
+				token, app_id, realm, extension);
+	}
+
+end:
+	switch_safe_free(sql);
+	if (dbh)
+	{
+		switch_cache_db_release_db_handle(&dbh);
+	}
+}
+
 static int do_curl(switch_event_t *event, profile_t *profile)
 {
 	switch_CURL *curl_handle = NULL;
@@ -264,6 +319,15 @@ static switch_bool_t mod_apn_send(switch_event_t *event, profile_t *profile)
 	}
 	else
 	{
+		if (http_code == 410)
+		{
+			const char *token = switch_event_get_header(event, "token");
+			const char *app_id = switch_event_get_header(event, "app_id");
+			const char *user = switch_event_get_header(event, "user");
+			const char *realm = switch_event_get_header(event, "realm");
+
+			mod_apn_delete_token(token, app_id, realm, user);
+		}
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
 						  "APN request failed with HTTP code: %d\n", http_code);
 	}


### PR DESCRIPTION
## Summary
- return HTTP 410 from the push helper when Firebase or APNs report invalid tokens while leaving successful sends at HTTP 200
- add a database cleanup helper so mod_apn removes expired tokens when APNs replies with 410
- note the new behaviour in the README for operators

## Testing
- php -l fcm_push.php

------
https://chatgpt.com/codex/tasks/task_b_68f46246c6c0832ab0b17aff04446492